### PR TITLE
[TEST-1198] Disable testmon's use of block level dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ nosetests.xml
 .*
 /htmlcov/
 /tags
+results.xml

--- a/jarvis-autotest/test3_junit_pr.sh
+++ b/jarvis-autotest/test3_junit_pr.sh
@@ -1,0 +1,8 @@
+
+#!/bin/bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $CURRENT_DIR/..
+
+pip install tox
+tox

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='pytest-testmon',
     description='find bugs 10x faster',
     long_description=''.join(open('README.rst').readlines()),
-    version='0.9.19',
+    version='0.9.19+dr0',
     license='MIT',
     platforms=['linux', 'osx', 'win32'],
     packages=['testmon'],

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -73,16 +73,20 @@ class TestGeneral(object):
 
 
 class TestDepGraph():
+    @pytest.mark.xfail
     def test_dep_graph1(self):
         assert is_dependent({'a.py': [101, 102]}, {'a.py': [101, 102, 3]}) == False
 
+    @pytest.mark.xfail
     def test_dep_graph_new(self):
         assert is_dependent({'a.py': [101, 102]}, {'new.py': get_modules([101, 102, 3]),
                                                    'a.py': get_modules([101, 102, 3])}) == False
 
+    @pytest.mark.xfail
     def test_dep_graph2(self):
         assert is_dependent({'a.py': [101, 102]}, {'a.py': get_modules([101, 102])}) == False
 
+    @pytest.mark.xfail
     def test_dep_graph3(self):
         assert is_dependent({'a.py': [101, 102]}, {'a.py': get_modules([101, 102, 103])}) == False
 
@@ -142,6 +146,7 @@ class TestDepGraph():
         assert is_dependent({'test_s.py': [bs1[1].checksum, bs1[2].checksum]},
                             {'test_s.py': [b.checksum for b in bs2]}) == True
 
+    @pytest.mark.xfail
     def test_affected_list(self, testdir):
         changes = {'test_a.py': [102, 103]}
 
@@ -172,11 +177,13 @@ def get_changed_files(dependencies, changes):
 
 
 class TestStable():
+    @pytest.mark.xfail
     def test_nothing_changed(self):
         changed = {'a.py': [101, 102, 103]}
         dependencies = {'test_a.py::node1': {'test_a.py': [201, 202], 'a.py': [101, 102, 103]}}
         assert stable(dependencies, blockify(changed))[0] == dependencies
 
+    @pytest.mark.xfail
     def test_simple_change(self):
         changed = {'a.py': [101, 102, 151]}
         dependencies = {'test_a.py::node1': {'test_a.py': [201, 202], 'a.py': [101, 102, 103]},
@@ -187,6 +194,7 @@ class TestStable():
         assert set(nodes) == {'test_b.py::node2'}
         assert set(files) == {'test_b.py'}
 
+    @pytest.mark.xfail
     def test_dependent_test_modules(self):
         dependencies = {'test_a.py::test_1': {'test_a.py': [1],
                                               'test_b.py': [3]},
@@ -202,6 +210,7 @@ class TestStable():
         assert set(nodes) == {'test_a.py::test_1'}
         assert set(files) == {'test_a.py'}
 
+    @pytest.mark.xfail
     def test_dependent_test_modules2(self):
         dependencies = {'test_a.py::test_1': {'test_a.py': [1],
                                               'test_b.py': [3],

--- a/testmon/testmon_core.py
+++ b/testmon/testmon_core.py
@@ -69,10 +69,8 @@ def stable(node_data, changed_files):
 
     for file in set(changed_files) & set(file_data):
         for nodeid, checksums in file_data[file].items():
-            if set(checksums) - set(changed_files[file].checksums): #the nodeid requires checksums which disapeared from
-                                                                    #the filesystem => the nodeid is "affected"
-                stable_nodes.pop(nodeid, None)
-                stable_files -= {nodeid.split('::', 1)[0], file}
+            stable_nodes.pop(nodeid, None)
+            stable_files -= {nodeid.split('::', 1)[0], file}
 
     return stable_nodes, stable_files
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,14 @@
 [tox]
-envlist = pytest{45,50,master,features}-py{35,37},py27-pytest45,py37-pytest45-xdist,pytestfeatures-py37
+envlist = pytest{35,45,50,master}-py37,py27-pytest{35, 45}
 
 [testenv]
 passenv = PYTHONPATH
 setenv = TESTMON_DATAFILE=.testmondata.tests
-commands = py.test --tb=native {posargs:test}
+commands = py.test --junitxml results.xml --tb=native {posargs:test}
 deps =
     coverage_pth
-    xdist: pytest-xdist
+    pytest35: pytest>=3.5,<3.6
     pytest45: pytest>=4.5,<4.6
     pytest50: pytest>=5.0.0,<5.1.0
     # master is current stable version with bugfixes.
     pytestmaster: git+https://github.com/pytest-dev/pytest.git@master#egg=pytest
-    # features is the next non-bugfix version.
-    pytestfeatures: git+https://github.com/pytest-dev/pytest.git@features#egg=pytest


### PR DESCRIPTION
https://github.com/datarobot/DataRobot/pull/57020 runs off this version and shows the same number of failed tests compared to the full suite while still running in about half the time.