### PR TITLE
[TEST-1266] Added configurable threshold for enabling the block level dependency graph

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='pytest-testmon',
     description='find bugs 10x faster',
     long_description=''.join(open('README.rst').readlines()),
-    version='0.9.19.post4',
+    version='0.9.19.post5',
     license='MIT',
     platforms=['linux', 'osx', 'win32'],
     packages=['testmon'],

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -3,8 +3,16 @@ from collections import namedtuple
 
 from testmon.process_code import Module, read_file_with_checksum
 from test.test_process_code import CodeSample
-from testmon.testmon_core import TestmonData as CoreTestmonData, SourceTree, flip_dictionary, stable, \
-    checksums_to_blob, CHECKUMS_ARRAY_TYPE, blob_to_checksums, node_data_to_test_files
+from testmon.testmon_core import (
+    TestmonData as CoreTestmonData,
+    SourceTree,
+    flip_dictionary,
+    stable,
+    checksums_to_blob,
+    CHECKUMS_ARRAY_TYPE,
+    blob_to_checksums,
+    node_data_to_test_files,
+)
 
 import sqlite3
 
@@ -73,20 +81,16 @@ class TestGeneral(object):
 
 
 class TestDepGraph():
-    @pytest.mark.xfail
     def test_dep_graph1(self):
         assert is_dependent({'a.py': [101, 102]}, {'a.py': [101, 102, 3]}) == False
 
-    @pytest.mark.xfail
     def test_dep_graph_new(self):
         assert is_dependent({'a.py': [101, 102]}, {'new.py': get_modules([101, 102, 3]),
                                                    'a.py': get_modules([101, 102, 3])}) == False
 
-    @pytest.mark.xfail
     def test_dep_graph2(self):
         assert is_dependent({'a.py': [101, 102]}, {'a.py': get_modules([101, 102])}) == False
 
-    @pytest.mark.xfail
     def test_dep_graph3(self):
         assert is_dependent({'a.py': [101, 102]}, {'a.py': get_modules([101, 102, 103])}) == False
 
@@ -146,7 +150,6 @@ class TestDepGraph():
         assert is_dependent({'test_s.py': [bs1[1].checksum, bs1[2].checksum]},
                             {'test_s.py': [b.checksum for b in bs2]}) == True
 
-    @pytest.mark.xfail
     def test_affected_list(self, testdir):
         changes = {'test_a.py': [102, 103]}
 
@@ -177,40 +180,48 @@ def get_changed_files(dependencies, changes):
 
 
 class TestStable():
-    @pytest.mark.xfail
     def test_nothing_changed(self):
         changed = {'a.py': [101, 102, 103]}
         dependencies = {'test_a.py::node1': {'test_a.py': [201, 202], 'a.py': [101, 102, 103]}}
-        assert stable(dependencies, blockify(changed))[0] == dependencies
+        assert stable(dependencies, blockify(changed), 1)[0] == dependencies
 
-    @pytest.mark.xfail
     def test_simple_change(self):
         changed = {'a.py': [101, 102, 151]}
         dependencies = {'test_a.py::node1': {'test_a.py': [201, 202], 'a.py': [101, 102, 103]},
                         'test_b.py::node2': {'test_b.py': [301, 302], 'a.py': [151]}}
 
-        nodes, files = stable(dependencies, blockify(changed))
+        nodes, files = stable(dependencies, blockify(changed), 1)
 
         assert set(nodes) == {'test_b.py::node2'}
         assert set(files) == {'test_b.py'}
 
-    @pytest.mark.xfail
+    def test_no_blocks(self):
+        changed = {'a.py': [101, 102, 151]}
+        dependencies = {'test_a.py::node1': {'test_a.py': [201, 202], 'a.py': [101, 102, 103]},
+                        'test_b.py::node2': {'test_b.py': [301, 302], 'a.py': [151]}}
+
+        nodes, files = stable(dependencies, blockify(changed), 0)
+
+        # If blocks are enabled, it will assume test_b.py is stable,
+        # but we want to test it anyway because the file dependency changed.
+        assert set(nodes) == set()
+        assert set(files) == set()
+
     def test_dependent_test_modules(self):
         dependencies = {'test_a.py::test_1': {'test_a.py': [1],
                                               'test_b.py': [3]},
                         'test_b.py::test_2': {'test_b.py': [2]}}
         changed = {'test_a.py': [-1]}
 
-        nodes, files = stable(dependencies, blockify(changed))
+        nodes, files = stable(dependencies, blockify(changed), 1)
         assert set(nodes) == {'test_b.py::test_2'}
         assert set(files) == {'test_b.py'}
 
         changed = {'test_b.py': [3]}
-        nodes, files = stable(dependencies, blockify(changed))
+        nodes, files = stable(dependencies, blockify(changed), 1)
         assert set(nodes) == {'test_a.py::test_1'}
         assert set(files) == {'test_a.py'}
 
-    @pytest.mark.xfail
     def test_dependent_test_modules2(self):
         dependencies = {'test_a.py::test_1': {'test_a.py': [1],
                                               'test_b.py': [3],
@@ -218,12 +229,12 @@ class TestStable():
                         'test_b.py::test_2': {'test_b.py': [2]}}
 
         changed_files = get_changed_files(dependencies, {'c.py': [4]})
-        nodes, files = stable(dependencies, blockify(changed_files))
+        nodes, files = stable(dependencies, blockify(changed_files), 1)
         assert set(nodes) == {'test_b.py::test_2'}
         assert set(files) == {'test_b.py'}
 
         changed_files = get_changed_files(dependencies, {'test_b.py': [2]})
-        nodes, files = stable(dependencies, blockify(changed_files))
+        nodes, files = stable(dependencies, blockify(changed_files), 1)
         assert set(nodes) == {'test_a.py::test_1'}
         assert set(files) == {'test_a.py', 'c.py'}
 
@@ -238,7 +249,11 @@ def is_dependent(dependencies, changes):
 
 
 def affected_nodeids(dependencies, changes):
-    stable_nodes, files = stable(dependencies, blockify(changes))
+    stable_nodes, files = stable(
+        dependencies,
+        blockify(changes),
+        len(changes),
+    )
     return set(dependencies) - set(stable_nodes)
 
 

--- a/testmon/pytest_testmon.py
+++ b/testmon/pytest_testmon.py
@@ -78,6 +78,12 @@ def pytest_addoption(parser):
         help="Top level directory of project",
         default=None
     )
+    group.addoption(
+        '--testmon-block-threshold',
+        help='Maximum number of files changed before disabling block level dependency checking',
+        type=int,
+        default=0
+    )
 
     parser.addini("run_variant_expression", "run variant expression",
                   default='')
@@ -95,9 +101,13 @@ def testmon_options(config):
 def init_testmon_data(config, read_source=True):
     if not hasattr(config, 'testmon_data'):
         variant = eval_variant(config.getini('run_variant_expression'))
+        
         config.project_dirs = config.getoption('project_directory') or [config.rootdir.strpath]
-        testmon_data = TestmonData(config.project_dirs[0],
-                                   variant=variant)
+        testmon_data = TestmonData(
+            config.project_dirs[0],
+            variant=variant,
+            block_threshold=config.getoption('testmon_block_threshold')
+        )
         testmon_data.read_data()
         if read_source:
             testmon_data.read_source()


### PR DESCRIPTION
Now that everything else is sorted out with our system integration of testmon, we can try experimenting with using the somewhat buggy block-level dependency graph to save costs while we continue work to upgrade to testmon v1