### PR TITLE
[TEST-1304] Memory optimizations for pytest-test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     name="pytest-testmon",
     description="selects tests affected by changed files and methods",
     long_description=long_description,
-    version="1.0.2.post2",
+    version="1.0.2.post3",
     license="AGPL",
     platforms=["linux", "osx", "win32"],
     packages=["testmon",],

--- a/testmon/process_code.py
+++ b/testmon/process_code.py
@@ -181,6 +181,9 @@ def create_fingerprints(afile, special_blocks, coverage):
 
 
 def file_has_lines(full_lines, fingerprints):
+    if fingerprints is None:
+        return False
+
     file_idx = 0
     fingerprint_idx = 0
 

--- a/testmon/process_code.py
+++ b/testmon/process_code.py
@@ -181,9 +181,6 @@ def create_fingerprints(afile, special_blocks, coverage):
 
 
 def file_has_lines(full_lines, fingerprints):
-    if fingerprints is None:
-        return False
-
     file_idx = 0
     fingerprint_idx = 0
 

--- a/testmon/pytest_testmon.py
+++ b/testmon/pytest_testmon.py
@@ -194,7 +194,6 @@ def pytest_unconfigure(config):
 
 
 def sort_items_by_duration(items, testmon_data):
-    # TODO: Optimize. This takes forever and probably isn't worth it
     durations = defaultdict(lambda: {"node_count": 0, "duration": 0})
     for item in items:
         item.duration = 0
@@ -285,7 +284,6 @@ class TestmonSelect:
 
     def add_failing_reports_from_db(self, failing_stable_nodes):
         """If the nodeid is failed but stable, add it's report instead of running it."""
-        # TODO: Ask team about what we want here
         for nodeid in failing_stable_nodes:
             node_report = self.testmon_data.get_report(nodeid)
             if not node_report:
@@ -310,7 +308,6 @@ class TestmonSelect:
         items[:] = selected
 
         if self.testmon_data.all_nodes and not config.getoption("testmon_nosort"):
-            raise Exception
             sort_items_by_duration(items, self.testmon_data)
 
         session.config.hook.pytest_deselected(

--- a/testmon/pytest_testmon.py
+++ b/testmon/pytest_testmon.py
@@ -3,15 +3,16 @@ from collections import defaultdict
 
 import pytest
 from _pytest.python import Function
+from _pytest import runner
+
 from testmon.testmon_core import (
     Testmon,
     eval_environment,
     TestmonData,
-    home_file,
     TestmonConfig,
     TestmonException,
 )
-from _pytest import runner
+
 
 
 def serialize_report(rep):
@@ -184,8 +185,6 @@ def pytest_report_header(config):
         stable_files=len(config.testmon_data.stable_files),
         changed_files=changed_files,
     )
-
-    return message
 
 
 def pytest_unconfigure(config):

--- a/testmon/pytest_testmon.py
+++ b/testmon/pytest_testmon.py
@@ -107,7 +107,7 @@ def init_testmon_data(config, read_source=True):
         environment = eval_environment(config.getini("environment_expression"))
         testmon_data = TestmonData(config.rootdir.strpath, environment=environment)
         if read_source:
-            testmon_data.determine_stable()
+            testmon_data.my_determine_stable()
         config.testmon_data = testmon_data
 
 

--- a/testmon/pytest_testmon.py
+++ b/testmon/pytest_testmon.py
@@ -90,7 +90,7 @@ def pytest_addoption(parser):
 
     group.addoption(
         "--testmon-nosort",
-        action="store_true",
+        action="store_false",
         dest="testmon_nosort",
         help="""
         Testmon sorts tests by execution time normally, this disables that feature. Useful

--- a/testmon/pytest_testmon.py
+++ b/testmon/pytest_testmon.py
@@ -102,7 +102,6 @@ def testmon_options(config):
             result.append(label.replace("testmon_", ""))
     return result
 
-
 def init_testmon_data(config, read_source=True):
     if not hasattr(config, "testmon_data"):
         environment = eval_environment(config.getini("environment_expression"))
@@ -116,7 +115,6 @@ def pytest_configure(config):
     coverage_stack = None
 
     plugin = None
-
 
     testmon_config = TestmonConfig()
     message, should_collect, should_select = testmon_config.header_collect_select(
@@ -187,6 +185,7 @@ def pytest_unconfigure(config):
 
 
 def sort_items_by_duration(items, testmon_data):
+    # TODO: Optimize. This takes forever and probably isn't worth it
     durations = defaultdict(lambda: {"node_count": 0, "duration": 0})
     for item in items:
         item.duration = 0

--- a/testmon/pytest_testmon.py
+++ b/testmon/pytest_testmon.py
@@ -290,7 +290,7 @@ class TestmonSelect:
                 continue
             for phase in ("setup", "call", "teardown"):
                 if phase in node_report:
-                    test_report = runner.TestReport(**node_reports[phase])
+                    test_report = runner.TestReport(**node_report[phase])
                     self.config.hook.pytest_runtest_logreport(report=test_report)
 
     def pytest_ignore_collect(self, path, config):

--- a/testmon/pytest_testmon.py
+++ b/testmon/pytest_testmon.py
@@ -301,8 +301,8 @@ class TestmonSelect:
         items[:] = selected
 
         # TODO: Add option to toggle this from config because the overhead is high
-        if self.testmon_data.all_nodes:
-            sort_items_by_duration(items, self.testmon_data)
+        # if self.testmon_data.all_nodes:
+        #     sort_items_by_duration(items, self.testmon_data)
 
         session.config.hook.pytest_deselected(
             items=([FakeItemFromTestmon(session.config)] * len(self.deselected_nodes))

--- a/testmon/testmon_core.py
+++ b/testmon/testmon_core.py
@@ -214,7 +214,7 @@ class TestmonData(object):
         )
         self.connection.execute(
             """
-            CREATE INDEX node-fingerprint-idx ON node_fingerprint (
+            CREATE INDEX node_fingerprint_idx ON node_fingerprint (
                 node_id,
                 fingerprint_id
             )
@@ -266,7 +266,7 @@ class TestmonData(object):
             SELECT DISTINCT
             f.file_name, f.mtime, f.checksum, f.id as fingerprint_id
             FROM fingerprint f
-            JOIN  node n ON n.id = nfp.node_id
+            JOIN node n ON n.id = nfp.node_id
             JOIN node_fingerprint nfp ON nfp.fingerprint_id = f.id
             WHERE environment =?
             """,


### PR DESCRIPTION
## RATIONALE
Reduce the memory footprint of TestMon on python 2.

## CHANGES
- Optimizes Sqlite queries with INNER joins
- Adds index on node_fingerprint table for faster queries
- Adds Sqlite page limit when querying to better fetch batches of results at a time.
- Remove JSON loading that was unnecessary and slow
- Adds command line option `--testmon-nosort` to prevent sorting test cases by execution time (and makes this the default behavior)


## NOTES
Working to reduce the memory footprint. The DB is only 800MiB, so it doesn't make any sense that we are using 8GiB of RAM. When measuring `self`, I only see the expected 700MiB and it never creeps above that, so the extra 7+ GiB of RAM happens somewhere outside while iterating through the SQLite DB.
![image](https://user-images.githubusercontent.com/596029/79286440-73f60d80-7e75-11ea-822f-0058a3e5b3ac.png)
I don't understand the second spike of RAM either...


I believe this is a Python2 issue, because in Python3 this is:
![image](https://user-images.githubusercontent.com/596029/79287570-0cda5800-7e79-11ea-8143-c022e8ddd171.png)

It might not be directly comparable due to the DB getting generated with Python2, so there are lot of bad fingerprints since AST changed quite a bit.

Here it is in Python 2 without testmon as a baseline:
![image](https://user-images.githubusercontent.com/596029/79288804-8d4e8800-7e7c-11ea-8bd3-3446b01e61f5.png)

It definitely is testmon creating both spikes
