### PR TITLE
[TEST-1573] Test selection performance improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     name="pytest-testmon",
     description="selects tests affected by changed files and methods",
     long_description=long_description,
-    version="1.0.2.post7",
+    version="1.0.2.post8",
     license="AGPL",
     platforms=["linux", "osx", "win32"],
     packages=["testmon",],

--- a/testmon/pytest_testmon.py
+++ b/testmon/pytest_testmon.py
@@ -90,7 +90,7 @@ def pytest_addoption(parser):
 
     group.addoption(
         "--testmon-nosort",
-        action="store_false",
+        action="store_true",
         dest="testmon_nosort",
         help="""
         Testmon sorts tests by execution time normally, this disables that feature. Useful

--- a/testmon/testmon_core.py
+++ b/testmon/testmon_core.py
@@ -156,9 +156,9 @@ class TestmonData(object):
         self.connection = sqlite3.connect(self.datafile)
         self.connection.execute("PRAGMA foreign_keys = TRUE ")
         self.connection.execute("PRAGMA recursive_triggers = TRUE ")
-        self.connection.execute("PRAGMA shrink_memory")
-        self.connection.execute("PRAGMA temp_store = FILE")
+        self.connection.execute("PRAGMA temp_store = MEMORY")
         self.connection.execute("PRAGMA auto_vacuum = INCREMENTAL")
+        self.connection.execute("PRAGMA cache_size = -1000000")  # 1 GiB
         self.connection.row_factory = sqlite3.Row
 
         if new_db:
@@ -452,6 +452,7 @@ class TestmonData(object):
         last_nfp_rowid = 0
         fingerprint_ids = ', '.join([str(fp) for fp in changed_fingerprints])
         while True:
+            self.connection.execute("PRAGMA shrink_memory")
             current_page = self.connection.execute(
                 """
                 SELECT


### PR DESCRIPTION
Running from the same code base and DB (DB is two days older than code), we had:

Baseline performance of --collectonly without testmon:  1.06 minutes
Performance before these changes: 24.5 minutes
Performance after these changes: 1.8 minutes

Memory usage is not significant, and for unit tests, doesn't climb about 1.5GiBs. We'll need to run this against integration once this gets published to make sure we don't OOM