### PR TITLE
[TEST-1525] Enforce uniqueness in node_fingerprint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     name="pytest-testmon",
     description="selects tests affected by changed files and methods",
     long_description=long_description,
-    version="1.0.2.post8",
+    version="1.0.2.post9",
     license="AGPL",
     platforms=["linux", "osx", "win32"],
     packages=["testmon",],

--- a/testmon/testmon_core.py
+++ b/testmon/testmon_core.py
@@ -194,7 +194,8 @@ class TestmonData(object):
                 node_id INTEGER,
                 fingerprint_id INTEGER,
                 FOREIGN KEY(node_id) REFERENCES node(id) ON DELETE CASCADE,
-                FOREIGN KEY(fingerprint_id) REFERENCES fingerprint(id)
+                FOREIGN KEY(fingerprint_id) REFERENCES fingerprint(id),
+                UNIQUE (node_id, fingerprint_id)
             )
             """
         )
@@ -382,7 +383,7 @@ class TestmonData(object):
                         (filename, fingerprint),
                     ).fetchone()[0]
                 cursor.execute(
-                    "INSERT INTO node_fingerprint VALUES (?, ?)",
+                    "INSERT OR IGNORE INTO node_fingerprint VALUES (?, ?)",
                     (node_id, fingerprint_id),
                 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = pytest{35,45,50,master}-py{37,38},py27-pytest{35, 45}
+skip_missing_interpreters = true
+
+[testenv]
+deps =
+    pytest35: pytest>=3.5,<3.6
+    pytest45: pytest>=4.5,<4.6
+    pytest50: pytest>=5.0.0,<5.1.0
+    # master is current stable version with bugfixes.
+    pytestmaster: git+https://github.com/pytest-dev/pytest.git@master#egg=pytest


### PR DESCRIPTION
# Changes
Add UNIQUENESS constraint and handle duplicate INSERTS into the node_fingerprint link table by ignore duplicate inserts.

## Testing
Verified with https://ci-test.devinfra.drdev.io/job/DataRobot_Testmon_Update_v1/93/ and DataRobot changes: 
https://github.com/datarobot/DataRobot/pull/67435